### PR TITLE
Add summer pruning course announcement for July 2026

### DIFF
--- a/src/data/ankuendigungen.ts
+++ b/src/data/ankuendigungen.ts
@@ -42,4 +42,10 @@ export const ankuendigungen: Ankuendigung[] = [
     hinweis:
       "Wanderung in Lindelburg (Oberdorf 5) ab 16:30 Uhr. Mitglieder und alle Naturfreunde herzlich willkommen!",
   },
+  {
+    datum: "11.07.2026",
+    titel: "Sommerschnittkurs",
+    uhrzeit: "15:00 Uhr",
+    ort: "Vereinsheim des OGV Winkelhaid",
+  },
 ];

--- a/src/data/veranstaltungen.ts
+++ b/src/data/veranstaltungen.ts
@@ -27,6 +27,10 @@ export const veranstaltungen: Veranstaltung[] = [
       "Kräuterwanderung mit Fr. Anita Schrödel in Lindelburg. Abfahrt 16:00 Uhr am Weiher in Altenthann, Start der Wanderung 16:30 Uhr in Lindelburg (Oberdorf 5).",
   },
   {
+    datum: "11.07.2026",
+    titel: "Sommerschnittkurs, 15:00 Uhr, Vereinsheim des OGV Winkelhaid",
+  },
+  {
     datum: "23.07.2026",
     titel: "Mostersitzung, 19:00 Uhr",
   },


### PR DESCRIPTION
## Summary
Added a new announcement for the summer pruning course ("Sommerschnittkurs") scheduled for July 11, 2026.

## Changes
- Added new announcement entry to `src/data/ankuendigungen.ts` with:
  - Date: July 11, 2026
  - Title: "Sommerschnittkurs" (Summer Pruning Course)
  - Time: 15:00 (3:00 PM)
  - Location: OGV Winkelhaid clubhouse ("Vereinsheim des OGV Winkelhaid")

This follows the existing announcement data structure and will be displayed on the announcements section of the website.

https://claude.ai/code/session_012Kur8NzvRMiXpwgr4q5fd4